### PR TITLE
fix(gateway): strip caller identity headers

### DIFF
--- a/lamp-dependencies-parent/pom.xml
+++ b/lamp-dependencies-parent/pom.xml
@@ -28,6 +28,8 @@
         <revision>5.10.0</revision>
         <!-- lamp-util基础库的版本 -->
         <lamp-util.version>5.10.0</lamp-util.version>
+        <skipTests>true</skipTests>
+        <maven.test.skip>true</maven.test.skip>
         <docker.image.prefix>zuihou</docker.image.prefix>
     </properties>
 
@@ -215,8 +217,8 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
-                        <skipTests>true</skipTests>
-                        <skip>true</skip>
+                        <skipTests>${skipTests}</skipTests>
+                        <skip>${maven.test.skip}</skip>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/lamp-gateway/lamp-gateway-server/src/main/java/top/tangyh/lamp/gateway/filter/TokenContextFilter.java
+++ b/lamp-gateway/lamp-gateway-server/src/main/java/top/tangyh/lamp/gateway/filter/TokenContextFilter.java
@@ -107,6 +107,7 @@ public class TokenContextFilter implements WebFilter, Ordered {
         ServerHttpRequest request = exchange.getRequest();
         ServerHttpResponse response = exchange.getResponse();
         ServerHttpRequest.Builder mutate = request.mutate();
+        removeIdentityHeaders(mutate);
 
         ContextUtil.setGrayVersion(getHeader(ContextConstants.GRAY_VERSION, request));
 
@@ -148,7 +149,8 @@ public class TokenContextFilter implements WebFilter, Ordered {
         // 判断接口是否需要忽略token验证
         if (isIgnoreToken(request)) {
             log.debug("当前接口：{}, 不解析用户token", request.getPath());
-            return chain.filter(exchange);
+            ServerHttpRequest build = mutate.build();
+            return chain.filter(exchange.mutate().request(build).build());
         }
 
         SaSession tokenSession = StpUtil.getTokenSessionByToken(getHeader(saTokenConfig.getTokenName(), request));
@@ -169,6 +171,16 @@ public class TokenContextFilter implements WebFilter, Ordered {
         }
 
         return null;
+    }
+
+    private void removeIdentityHeaders(ServerHttpRequest.Builder mutate) {
+        mutate.headers(headers -> {
+            headers.remove(USER_ID_HEADER);
+            headers.remove(EMPLOYEE_ID_HEADER);
+            headers.remove(CURRENT_TOP_COMPANY_ID_HEADER);
+            headers.remove(CURRENT_COMPANY_ID_HEADER);
+            headers.remove(CURRENT_DEPT_ID_HEADER);
+        });
     }
 
     private void parseClient(ServerHttpRequest request, ServerHttpRequest.Builder mutate) {

--- a/lamp-gateway/lamp-gateway-server/src/test/java/top/tangyh/lamp/gateway/filter/TokenContextFilterTest.java
+++ b/lamp-gateway/lamp-gateway-server/src/test/java/top/tangyh/lamp/gateway/filter/TokenContextFilterTest.java
@@ -1,0 +1,57 @@
+package top.tangyh.lamp.gateway.filter;
+
+import cn.dev33.satoken.config.SaTokenConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import top.tangyh.lamp.common.properties.IgnoreProperties;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static top.tangyh.basic.context.ContextConstants.CURRENT_COMPANY_ID_HEADER;
+import static top.tangyh.basic.context.ContextConstants.CURRENT_DEPT_ID_HEADER;
+import static top.tangyh.basic.context.ContextConstants.CURRENT_TOP_COMPANY_ID_HEADER;
+import static top.tangyh.basic.context.ContextConstants.EMPLOYEE_ID_HEADER;
+import static top.tangyh.basic.context.ContextConstants.USER_ID_HEADER;
+
+class TokenContextFilterTest {
+
+    @Test
+    void ignoredTokenRouteRemovesCallerSuppliedIdentityHeaders() {
+        IgnoreProperties ignoreProperties = new IgnoreProperties();
+        ignoreProperties.setAnyUser(Map.of("ALL", Set.of("/anyUser/**")));
+        TokenContextFilter filter = new TokenContextFilter(new SaTokenConfig(), ignoreProperties);
+
+        MockServerHttpRequest request = MockServerHttpRequest.get("/anyUser/ping")
+                .header(USER_ID_HEADER, "1001")
+                .header(EMPLOYEE_ID_HEADER, "2002")
+                .header(CURRENT_TOP_COMPANY_ID_HEADER, "3003")
+                .header(CURRENT_COMPANY_ID_HEADER, "4004")
+                .header(CURRENT_DEPT_ID_HEADER, "5005")
+                .header("X-Trace-Id", "trace-1")
+                .build();
+        MockServerWebExchange exchange = MockServerWebExchange.from(request);
+        AtomicReference<ServerHttpRequest> forwardedRequest = new AtomicReference<>();
+        WebFilterChain chain = forwardedExchange -> {
+            forwardedRequest.set(forwardedExchange.getRequest());
+            return Mono.empty();
+        };
+
+        filter.filter(exchange, chain).block();
+
+        assertThat(forwardedRequest).hasValueSatisfying(forwarded -> {
+            assertThat(forwarded.getHeaders().getFirst(USER_ID_HEADER)).isNull();
+            assertThat(forwarded.getHeaders().getFirst(EMPLOYEE_ID_HEADER)).isNull();
+            assertThat(forwarded.getHeaders().getFirst(CURRENT_TOP_COMPANY_ID_HEADER)).isNull();
+            assertThat(forwarded.getHeaders().getFirst(CURRENT_COMPANY_ID_HEADER)).isNull();
+            assertThat(forwarded.getHeaders().getFirst(CURRENT_DEPT_ID_HEADER)).isNull();
+            assertThat(forwarded.getHeaders().getFirst("X-Trace-Id")).isEqualTo("trace-1");
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Remove caller-supplied identity headers before gateway token handling.
- Forward the sanitized request on token-ignored routes; authenticated routes still set identity headers from the token session.
- Keep surefire tests skipped by default, but allow explicit CLI overrides for targeted regression tests.

## Tests
- `mvn -pl lamp-gateway/lamp-gateway-server -am -DskipTests=false -Dmaven.test.skip=false -Dtest=TokenContextFilterTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
